### PR TITLE
fix(docker): remove stale reference to deleted Generation project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
-COPY *.slnx global.json ./
+COPY global.json ./
 COPY FL.LigaImmich/FL.LigaImmich.csproj FL.LigaImmich/
 COPY FL.LigaImmich.ImmichClient/FL.LigaImmich.ImmichClient.csproj FL.LigaImmich.ImmichClient/
-COPY FL.LigaImmich.ImmichClient.Generation/FL.LigaImmich.ImmichClient.Generation.csproj FL.LigaImmich.ImmichClient.Generation/
-RUN dotnet restore
+RUN dotnet restore FL.LigaImmich/FL.LigaImmich.csproj
 
 COPY . .
 RUN dotnet publish FL.LigaImmich/FL.LigaImmich.csproj -c Release -o /app/publish --no-restore


### PR DESCRIPTION
## Summary
- [Dockerfile:7](Dockerfile#L7) copied `FL.LigaImmich.ImmichClient.Generation/FL.LigaImmich.ImmichClient.Generation.csproj`, but that project was removed in f927ff6/58b3382 when NSwag began generating the client inline from the committed OpenAPI spec. This broke the GHCR image build ([run 24600608183](https://github.com/mstroppel/LigaImmich/actions/runs/24600608183/job/71938545982)) with `failed to calculate checksum ... not found`.
- Also target the worker csproj in `dotnet restore` so it no longer resolves the full `.slnx` — which now includes `FL.LigaImmich.Tests`, whose csproj is intentionally not copied into the image.

## Test plan
- [x] `dotnet restore FL.LigaImmich/FL.LigaImmich.csproj` succeeds locally
- [x] `dotnet publish FL.LigaImmich/FL.LigaImmich.csproj -c Release --no-restore` succeeds locally
- [ ] GHCR "Build & Push Docker Image" workflow succeeds on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)