### PR TITLE
feat(tasks): nest club tags under Vereine parent (#17)

### DIFF
--- a/FL.LigaImmich.Tests/ClubFolderMapTests.cs
+++ b/FL.LigaImmich.Tests/ClubFolderMapTests.cs
@@ -5,12 +5,12 @@ namespace FL.LigaImmich.Tests;
 public class ClubFolderMapTests
 {
     [Theory]
-    [InlineData("Digitalfoto/2025/M-Musikverein/M_2025-01-11_Konzert/M_2025-01-11_001.JPG", "Musikverein")]
-    [InlineData("/Digitalfoto/2024/N-Narrenzunft/Umzug", "Narrenzunft")]
-    [InlineData("Digitalfoto\\2025\\C-Gemischter_Chor\\Auftritt", "Gemischter Chor")]
-    [InlineData("Digitalfoto/2025/P-Personen_und_Begebenheiten/event", "Personen und Begebenheiten")]
-    [InlineData("Digitalfoto/2025/T-TSV", "TSV")]
-    public void TryResolveTag_ReturnsTagName_ForKnownClubFolder(string path, string expected)
+    [InlineData("Digitalfoto/2025/M-Musikverein/M_2025-01-11_Konzert/M_2025-01-11_001.JPG", "Vereine/Musikverein")]
+    [InlineData("/Digitalfoto/2024/N-Narrenzunft/Umzug", "Vereine/Narrenzunft")]
+    [InlineData("Digitalfoto\\2025\\C-Gemischter_Chor\\Auftritt", "Vereine/Gemischter Chor")]
+    [InlineData("Digitalfoto/2025/P-Personen_und_Begebenheiten/event", "Vereine/Personen und Begebenheiten")]
+    [InlineData("Digitalfoto/2025/T-TSV", "Vereine/TSV")]
+    public void TryResolveTag_ReturnsNestedTagValue_ForKnownClubFolder(string path, string expected)
     {
         Assert.True(ClubFolderMap.TryResolveTag(path, out var tag));
         Assert.Equal(expected, tag);
@@ -30,15 +30,22 @@ public class ClubFolderMapTests
     public void TryResolveTag_IsCaseInsensitive_OnFolderToken()
     {
         Assert.True(ClubFolderMap.TryResolveTag("Digitalfoto/2025/m-musikverein/img.jpg", out var tag));
-        Assert.Equal("Musikverein", tag);
+        Assert.Equal("Vereine/Musikverein", tag);
     }
 
     [Fact]
-    public void TagNames_IncludesAllExpectedClubs()
+    public void LeafTagNames_IncludesAllExpectedClubs()
     {
-        Assert.Contains("Musikverein", ClubFolderMap.TagNames);
-        Assert.Contains("Feuerwehr", ClubFolderMap.TagNames);
-        Assert.Contains("Kegler", ClubFolderMap.TagNames);
-        Assert.Equal(17, ClubFolderMap.TagNames.Count);
+        Assert.Contains("Musikverein", ClubFolderMap.LeafTagNames);
+        Assert.Contains("Feuerwehr", ClubFolderMap.LeafTagNames);
+        Assert.Contains("Kegler", ClubFolderMap.LeafTagNames);
+        Assert.Equal(17, ClubFolderMap.LeafTagNames.Count);
+    }
+
+    [Fact]
+    public void TagValues_AreAllNestedUnderVereineParent()
+    {
+        Assert.Equal(ClubFolderMap.LeafTagNames.Count, ClubFolderMap.TagValues.Count);
+        Assert.All(ClubFolderMap.TagValues, value => Assert.StartsWith("Vereine/", value));
     }
 }

--- a/FL.LigaImmich/Clubs/ClubFolderMap.cs
+++ b/FL.LigaImmich/Clubs/ClubFolderMap.cs
@@ -2,8 +2,10 @@ namespace FL.LigaImmich.Clubs;
 
 internal static class ClubFolderMap
 {
+    public const string ParentTag = "Vereine";
+
     // Source of truth: https://github.com/filmliga66/archivstruktur/blob/main/reference/clubs.json
-    private static readonly Dictionary<string, string> FolderToTag = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, string> FolderToLeafTag = new(StringComparer.OrdinalIgnoreCase)
     {
         ["A-Albverein"] = "Albverein",
         ["C-Gemischter_Chor"] = "Gemischter Chor",
@@ -24,26 +26,31 @@ internal static class ClubFolderMap
         ["Z-Kegler"] = "Kegler",
     };
 
-    public static IReadOnlyCollection<string> TagNames { get; } =
-        FolderToTag.Values.Distinct(StringComparer.Ordinal).ToArray();
+    public static IReadOnlyCollection<string> LeafTagNames { get; } =
+        FolderToLeafTag.Values.Distinct(StringComparer.Ordinal).ToArray();
 
-    public static bool TryResolveTag(string path, out string tagName)
+    public static IReadOnlyCollection<string> TagValues { get; } =
+        LeafTagNames.Select(ToTagValue).ToArray();
+
+    public static bool TryResolveTag(string path, out string tagValue)
     {
         if (!string.IsNullOrEmpty(path))
         {
             foreach (var segment in path.Split(Separators, StringSplitOptions.RemoveEmptyEntries))
             {
-                if (FolderToTag.TryGetValue(segment, out var resolved))
+                if (FolderToLeafTag.TryGetValue(segment, out var leaf))
                 {
-                    tagName = resolved;
+                    tagValue = ToTagValue(leaf);
                     return true;
                 }
             }
         }
 
-        tagName = string.Empty;
+        tagValue = string.Empty;
         return false;
     }
+
+    public static string ToTagValue(string leaf) => $"{ParentTag}/{leaf}";
 
     private static readonly char[] Separators = ['/', '\\'];
 }

--- a/FL.LigaImmich/Tasks/TagAssetsByClubTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByClubTask.cs
@@ -22,7 +22,9 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
 
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        var tagIdByName = await EnsureClubTagsAsync(cancellationToken);
+        await RemoveLegacyFlatClubTagsAsync(cancellationToken);
+
+        var tagIdByValue = await EnsureClubTagsAsync(cancellationToken);
 
         var folderPaths = await _immichClient.GetUniqueOriginalPathsAsync(cancellationToken);
         _logger.LogInformation("Fetched {Count} unique folder paths from Immich.", folderPaths.Count);
@@ -31,7 +33,7 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
 
         foreach (var folder in folderPaths)
         {
-            if (!ClubFolderMap.TryResolveTag(folder, out var tagName))
+            if (!ClubFolderMap.TryResolveTag(folder, out var tagValue))
             {
                 continue;
             }
@@ -42,9 +44,9 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
                 continue;
             }
 
-            if (!assetsByTag.TryGetValue(tagName, out var set))
+            if (!assetsByTag.TryGetValue(tagValue, out var set))
             {
-                assetsByTag[tagName] = set = [];
+                assetsByTag[tagValue] = set = [];
             }
 
             foreach (var asset in assets)
@@ -56,16 +58,16 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
             }
         }
 
-        foreach (var (tagName, assetIds) in assetsByTag)
+        foreach (var (tagValue, assetIds) in assetsByTag)
         {
             if (assetIds.Count == 0)
             {
                 continue;
             }
 
-            if (!tagIdByName.TryGetValue(tagName, out var tagId))
+            if (!tagIdByValue.TryGetValue(tagValue, out var tagId))
             {
-                _logger.LogWarning("Skipping tag {TagName}: no id resolved after upsert.", tagName);
+                _logger.LogWarning("Skipping tag {TagValue}: no id resolved after upsert.", tagValue);
                 continue;
             }
 
@@ -85,29 +87,56 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
                 tagged += response.Count;
             }
 
-            _logger.LogInformation("Tagged {Tagged}/{Total} assets with {TagName}.", tagged, assetIds.Count, tagName);
+            _logger.LogInformation("Tagged {Tagged}/{Total} assets with {TagValue}.", tagged, assetIds.Count, tagValue);
         }
     }
 
     private async Task<Dictionary<string, Guid>> EnsureClubTagsAsync(CancellationToken cancellationToken)
     {
         var upsert = new TagUpsertDto();
-        foreach (var name in ClubFolderMap.TagNames)
+        foreach (var value in ClubFolderMap.TagValues)
         {
-            upsert.Tags.Add(name);
+            upsert.Tags.Add(value);
         }
 
         var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
 
-        var byName = new Dictionary<string, Guid>(StringComparer.Ordinal);
+        var byValue = new Dictionary<string, Guid>(StringComparer.Ordinal);
         foreach (var tag in tags)
         {
             if (Guid.TryParse(tag.Id, out var id))
             {
-                byName[tag.Value] = id;
+                byValue[tag.Value] = id;
             }
         }
 
-        return byName;
+        return byValue;
+    }
+
+    private async Task RemoveLegacyFlatClubTagsAsync(CancellationToken cancellationToken)
+    {
+        var allTags = await _immichClient.GetAllTagsAsync(cancellationToken);
+        var legacyLeafNames = new HashSet<string>(ClubFolderMap.LeafTagNames, StringComparer.Ordinal);
+
+        foreach (var tag in allTags)
+        {
+            if (!string.IsNullOrEmpty(tag.ParentId))
+            {
+                continue;
+            }
+
+            if (!legacyLeafNames.Contains(tag.Value))
+            {
+                continue;
+            }
+
+            if (!Guid.TryParse(tag.Id, out var id))
+            {
+                continue;
+            }
+
+            await _immichClient.DeleteTagAsync(id, cancellationToken);
+            _logger.LogInformation("Removed legacy flat club tag {TagValue} ({TagId}); assets will be re-tagged under {ParentTag}.", tag.Value, id, ClubFolderMap.ParentTag);
+        }
     }
 }


### PR DESCRIPTION
Closes #17.

## Summary
- All club tags (`Albverein`, `Film-Liga`, `Musikverein`, …) are now upserted as `Vereine/<Club>`, which Immich resolves as a child tag under a shared `Vereine` parent.
- `ClubFolderMap.TryResolveTag` now returns the full nested tag value; the leaf/folder mapping is still the single source of truth.
- At the start of each `TagAssetsByClub` run, any pre-existing flat club tags (matching a known leaf name with no parent) are deleted via `DeleteTag`. Their assets are re-tagged under `Vereine/<Club>` during the same run, so no manual migration is required.

## Test plan
- [x] `dotnet build FL.LigaImmich.slnx`
- [x] `dotnet test FL.LigaImmich.slnx` — 16/16 passing, including updated `ClubFolderMapTests` asserting nested values
- [x] Manually verify in staging Immich that after one scheduled run:
  - a `Vereine` parent tag exists
  - each club tag appears beneath it
  - the old flat club tags are gone and assets retain their (now nested) club tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)