### PR TITLE
chore(logging): json logs in production

### DIFF
--- a/FL.LigaImmich/appsettings.json
+++ b/FL.LigaImmich/appsettings.json
@@ -1,8 +1,11 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "Console": {
+      "FormatterName": "json"
     }
   },
   "Scheduler": {

--- a/FL.LigaImmich/appsettings.json
+++ b/FL.LigaImmich/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning",
+      "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     },
     "Console": {


### PR DESCRIPTION
## Summary
- Sets `Logging:Console:FormatterName` to `json` in [appsettings.json](FL.LigaImmich/appsettings.json) so Production (and any non-Development environment) emits structured JSON to stdout — easier to parse for log aggregators.
- [appsettings.Development.json](FL.LigaImmich/appsettings.Development.json) is untouched, so local `dotnet run` keeps the default simple (human-readable) console formatter.

## Test plan
- [x] `dotnet build FL.LigaImmich.slnx`
- [ ] `ASPNETCORE_ENVIRONMENT=Production dotnet run` locally — verify log lines are JSON objects
- [ ] `dotnet run` (defaults to Development) — verify log lines stay in plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)