### PR TITLE
chore: add Remove-AllTags.ps1 script

### DIFF
--- a/FL.LigaImmich.Tests/ClubFolderMapTests.cs
+++ b/FL.LigaImmich.Tests/ClubFolderMapTests.cs
@@ -5,12 +5,12 @@ namespace FL.LigaImmich.Tests;
 public class ClubFolderMapTests
 {
     [Theory]
-    [InlineData("Digitalfoto/2025/M-Musikverein/M_2025-01-11_Konzert/M_2025-01-11_001.JPG", "Musikverein")]
-    [InlineData("/Digitalfoto/2024/N-Narrenzunft/Umzug", "Narrenzunft")]
-    [InlineData("Digitalfoto\\2025\\C-Gemischter_Chor\\Auftritt", "Gemischter Chor")]
-    [InlineData("Digitalfoto/2025/P-Personen_und_Begebenheiten/event", "Personen und Begebenheiten")]
-    [InlineData("Digitalfoto/2025/T-TSV", "TSV")]
-    public void TryResolveTag_ReturnsTagName_ForKnownClubFolder(string path, string expected)
+    [InlineData("Digitalfoto/2025/M-Musikverein/M_2025-01-11_Konzert/M_2025-01-11_001.JPG", "Vereine/Musikverein")]
+    [InlineData("/Digitalfoto/2024/N-Narrenzunft/Umzug", "Vereine/Narrenzunft")]
+    [InlineData("Digitalfoto\\2025\\C-Gemischter_Chor\\Auftritt", "Vereine/Gemischter Chor")]
+    [InlineData("Digitalfoto/2025/P-Personen_und_Begebenheiten/event", "Vereine/Personen und Begebenheiten")]
+    [InlineData("Digitalfoto/2025/T-TSV", "Vereine/TSV")]
+    public void TryResolveTag_ReturnsNestedTagValue_ForKnownClubFolder(string path, string expected)
     {
         Assert.True(ClubFolderMap.TryResolveTag(path, out var tag));
         Assert.Equal(expected, tag);
@@ -30,15 +30,22 @@ public class ClubFolderMapTests
     public void TryResolveTag_IsCaseInsensitive_OnFolderToken()
     {
         Assert.True(ClubFolderMap.TryResolveTag("Digitalfoto/2025/m-musikverein/img.jpg", out var tag));
-        Assert.Equal("Musikverein", tag);
+        Assert.Equal("Vereine/Musikverein", tag);
     }
 
     [Fact]
-    public void TagNames_IncludesAllExpectedClubs()
+    public void LeafTagNames_IncludesAllExpectedClubs()
     {
-        Assert.Contains("Musikverein", ClubFolderMap.TagNames);
-        Assert.Contains("Feuerwehr", ClubFolderMap.TagNames);
-        Assert.Contains("Kegler", ClubFolderMap.TagNames);
-        Assert.Equal(17, ClubFolderMap.TagNames.Count);
+        Assert.Contains("Musikverein", ClubFolderMap.LeafTagNames);
+        Assert.Contains("Feuerwehr", ClubFolderMap.LeafTagNames);
+        Assert.Contains("Kegler", ClubFolderMap.LeafTagNames);
+        Assert.Equal(17, ClubFolderMap.LeafTagNames.Count);
+    }
+
+    [Fact]
+    public void TagValues_AreAllNestedUnderVereineParent()
+    {
+        Assert.Equal(ClubFolderMap.LeafTagNames.Count, ClubFolderMap.TagValues.Count);
+        Assert.All(ClubFolderMap.TagValues, value => Assert.StartsWith("Vereine/", value));
     }
 }

--- a/FL.LigaImmich/Clubs/ClubFolderMap.cs
+++ b/FL.LigaImmich/Clubs/ClubFolderMap.cs
@@ -2,8 +2,10 @@ namespace FL.LigaImmich.Clubs;
 
 internal static class ClubFolderMap
 {
+    public const string ParentTag = "Vereine";
+
     // Source of truth: https://github.com/filmliga66/archivstruktur/blob/main/reference/clubs.json
-    private static readonly Dictionary<string, string> FolderToTag = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, string> FolderToLeafTag = new(StringComparer.OrdinalIgnoreCase)
     {
         ["A-Albverein"] = "Albverein",
         ["C-Gemischter_Chor"] = "Gemischter Chor",
@@ -24,26 +26,31 @@ internal static class ClubFolderMap
         ["Z-Kegler"] = "Kegler",
     };
 
-    public static IReadOnlyCollection<string> TagNames { get; } =
-        FolderToTag.Values.Distinct(StringComparer.Ordinal).ToArray();
+    public static IReadOnlyCollection<string> LeafTagNames { get; } =
+        FolderToLeafTag.Values.Distinct(StringComparer.Ordinal).ToArray();
 
-    public static bool TryResolveTag(string path, out string tagName)
+    public static IReadOnlyCollection<string> TagValues { get; } =
+        LeafTagNames.Select(ToTagValue).ToArray();
+
+    public static bool TryResolveTag(string path, out string tagValue)
     {
         if (!string.IsNullOrEmpty(path))
         {
             foreach (var segment in path.Split(Separators, StringSplitOptions.RemoveEmptyEntries))
             {
-                if (FolderToTag.TryGetValue(segment, out var resolved))
+                if (FolderToLeafTag.TryGetValue(segment, out var leaf))
                 {
-                    tagName = resolved;
+                    tagValue = ToTagValue(leaf);
                     return true;
                 }
             }
         }
 
-        tagName = string.Empty;
+        tagValue = string.Empty;
         return false;
     }
+
+    public static string ToTagValue(string leaf) => $"{ParentTag}/{leaf}";
 
     private static readonly char[] Separators = ['/', '\\'];
 }

--- a/FL.LigaImmich/Tasks/TagAssetsByClubTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByClubTask.cs
@@ -22,7 +22,9 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
 
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        var tagIdByName = await EnsureClubTagsAsync(cancellationToken);
+        await RemoveLegacyFlatClubTagsAsync(cancellationToken);
+
+        var tagIdByValue = await EnsureClubTagsAsync(cancellationToken);
 
         var folderPaths = await _immichClient.GetUniqueOriginalPathsAsync(cancellationToken);
         _logger.LogInformation("Fetched {Count} unique folder paths from Immich.", folderPaths.Count);
@@ -31,7 +33,7 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
 
         foreach (var folder in folderPaths)
         {
-            if (!ClubFolderMap.TryResolveTag(folder, out var tagName))
+            if (!ClubFolderMap.TryResolveTag(folder, out var tagValue))
             {
                 continue;
             }
@@ -42,9 +44,9 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
                 continue;
             }
 
-            if (!assetsByTag.TryGetValue(tagName, out var set))
+            if (!assetsByTag.TryGetValue(tagValue, out var set))
             {
-                assetsByTag[tagName] = set = [];
+                assetsByTag[tagValue] = set = [];
             }
 
             foreach (var asset in assets)
@@ -56,16 +58,16 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
             }
         }
 
-        foreach (var (tagName, assetIds) in assetsByTag)
+        foreach (var (tagValue, assetIds) in assetsByTag)
         {
             if (assetIds.Count == 0)
             {
                 continue;
             }
 
-            if (!tagIdByName.TryGetValue(tagName, out var tagId))
+            if (!tagIdByValue.TryGetValue(tagValue, out var tagId))
             {
-                _logger.LogWarning("Skipping tag {TagName}: no id resolved after upsert.", tagName);
+                _logger.LogWarning("Skipping tag {TagValue}: no id resolved after upsert.", tagValue);
                 continue;
             }
 
@@ -85,29 +87,56 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
                 tagged += response.Count;
             }
 
-            _logger.LogInformation("Tagged {Tagged}/{Total} assets with {TagName}.", tagged, assetIds.Count, tagName);
+            _logger.LogInformation("Tagged {Tagged}/{Total} assets with {TagValue}.", tagged, assetIds.Count, tagValue);
         }
     }
 
     private async Task<Dictionary<string, Guid>> EnsureClubTagsAsync(CancellationToken cancellationToken)
     {
         var upsert = new TagUpsertDto();
-        foreach (var name in ClubFolderMap.TagNames)
+        foreach (var value in ClubFolderMap.TagValues)
         {
-            upsert.Tags.Add(name);
+            upsert.Tags.Add(value);
         }
 
         var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
 
-        var byName = new Dictionary<string, Guid>(StringComparer.Ordinal);
+        var byValue = new Dictionary<string, Guid>(StringComparer.Ordinal);
         foreach (var tag in tags)
         {
             if (Guid.TryParse(tag.Id, out var id))
             {
-                byName[tag.Value] = id;
+                byValue[tag.Value] = id;
             }
         }
 
-        return byName;
+        return byValue;
+    }
+
+    private async Task RemoveLegacyFlatClubTagsAsync(CancellationToken cancellationToken)
+    {
+        var allTags = await _immichClient.GetAllTagsAsync(cancellationToken);
+        var legacyLeafNames = new HashSet<string>(ClubFolderMap.LeafTagNames, StringComparer.Ordinal);
+
+        foreach (var tag in allTags)
+        {
+            if (!string.IsNullOrEmpty(tag.ParentId))
+            {
+                continue;
+            }
+
+            if (!legacyLeafNames.Contains(tag.Value))
+            {
+                continue;
+            }
+
+            if (!Guid.TryParse(tag.Id, out var id))
+            {
+                continue;
+            }
+
+            await _immichClient.DeleteTagAsync(id, cancellationToken);
+            _logger.LogInformation("Removed legacy flat club tag {TagValue} ({TagId}); assets will be re-tagged under {ParentTag}.", tag.Value, id, ClubFolderMap.ParentTag);
+        }
     }
 }

--- a/Remove-AllTags.ps1
+++ b/Remove-AllTags.ps1
@@ -68,6 +68,9 @@ if ([string]::IsNullOrWhiteSpace($baseUrl)) { throw "IMMICH_BASE_URL missing in 
 if ([string]::IsNullOrWhiteSpace($apiKey))  { throw "IMMICH_API_KEY missing in $EnvFile"  }
 
 $baseUrl = $baseUrl.TrimEnd('/')
+if ($baseUrl -notmatch '/api$') {
+    $baseUrl = "$baseUrl/api"
+}
 
 $headers = @{
     'x-api-key' = $apiKey

--- a/Remove-AllTags.ps1
+++ b/Remove-AllTags.ps1
@@ -1,0 +1,112 @@
+<#
+.SYNOPSIS
+    Deletes ALL tags from an Immich instance, using credentials from a .env file.
+
+.DESCRIPTION
+    Reads IMMICH_BASE_URL and IMMICH_API_KEY from the given .env file
+    (default: .env next to this script), lists every tag via GET /tags,
+    and deletes each one via DELETE /tags/{id}.
+
+    This is DESTRUCTIVE: tag-to-asset associations are lost, and any
+    tag hierarchy is removed. Assets themselves are kept.
+
+.PARAMETER EnvFile
+    Path to the .env file. Defaults to ./.env next to this script.
+
+.PARAMETER Force
+    Skip the interactive confirmation prompt.
+
+.EXAMPLE
+    ./Remove-AllTags.ps1
+
+.EXAMPLE
+    ./Remove-AllTags.ps1 -EnvFile ./.env.staging -Force
+#>
+[CmdletBinding()]
+param(
+    [string]$EnvFile = (Join-Path $PSScriptRoot '.env'),
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Read-DotEnv {
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw ".env file not found: $Path"
+    }
+
+    $values = @{}
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        $trimmed = $line.Trim()
+        if ($trimmed -eq '' -or $trimmed.StartsWith('#')) { continue }
+
+        $eq = $trimmed.IndexOf('=')
+        if ($eq -lt 1) { continue }
+
+        $key = $trimmed.Substring(0, $eq).Trim()
+        $val = $trimmed.Substring($eq + 1).Trim()
+
+        # Strip surrounding quotes if present
+        if (($val.StartsWith('"') -and $val.EndsWith('"')) -or
+            ($val.StartsWith("'") -and $val.EndsWith("'"))) {
+            $val = $val.Substring(1, $val.Length - 2)
+        }
+
+        $values[$key] = $val
+    }
+    return $values
+}
+
+$envValues = Read-DotEnv -Path $EnvFile
+
+$baseUrl = $envValues['IMMICH_BASE_URL']
+$apiKey  = $envValues['IMMICH_API_KEY']
+
+if ([string]::IsNullOrWhiteSpace($baseUrl)) { throw "IMMICH_BASE_URL missing in $EnvFile" }
+if ([string]::IsNullOrWhiteSpace($apiKey))  { throw "IMMICH_API_KEY missing in $EnvFile"  }
+
+$baseUrl = $baseUrl.TrimEnd('/')
+
+$headers = @{
+    'x-api-key' = $apiKey
+    'Accept'    = 'application/json'
+}
+
+Write-Host "Fetching tags from $baseUrl ..."
+$tags = Invoke-RestMethod -Method Get -Uri "$baseUrl/tags" -Headers $headers
+
+if (-not $tags -or $tags.Count -eq 0) {
+    Write-Host "No tags found. Nothing to do."
+    return
+}
+
+Write-Host ("Found {0} tag(s):" -f $tags.Count)
+$tags | Sort-Object value | ForEach-Object {
+    Write-Host ("  - {0}  ({1})" -f $_.value, $_.id)
+}
+
+if (-not $Force) {
+    $answer = Read-Host "Delete ALL $($tags.Count) tags? Type 'yes' to confirm"
+    if ($answer -ne 'yes') {
+        Write-Host "Aborted."
+        return
+    }
+}
+
+$deleted = 0
+$failed  = 0
+foreach ($tag in $tags) {
+    try {
+        Invoke-RestMethod -Method Delete -Uri "$baseUrl/tags/$($tag.id)" -Headers $headers | Out-Null
+        $deleted++
+        Write-Host ("Deleted {0} ({1})" -f $tag.value, $tag.id)
+    } catch {
+        $failed++
+        Write-Warning ("Failed to delete {0} ({1}): {2}" -f $tag.value, $tag.id, $_.Exception.Message)
+    }
+}
+
+Write-Host ""
+Write-Host ("Done. Deleted {0}/{1} tag(s). Failed: {2}." -f $deleted, $tags.Count, $failed)


### PR DESCRIPTION
## Summary
Adds [Remove-AllTags.ps1](Remove-AllTags.ps1), a one-shot admin script that:
- reads \`IMMICH_BASE_URL\` / \`IMMICH_API_KEY\` from a .env file (defaults to \`./.env\` next to the script),
- lists every tag via \`GET /tags\`,
- confirms interactively (skip with \`-Force\`),
- deletes each tag via \`DELETE /tags/{id}\`.

Handy for resetting tag state before the first run of the new Vereine-nested tagging behavior (see #18).

## Usage
\`\`\`pwsh
./Remove-AllTags.ps1                            # uses ./.env, confirms interactively
./Remove-AllTags.ps1 -EnvFile ./.env.staging    # alt env file
./Remove-AllTags.ps1 -Force                     # no prompt
\`\`\`

## Test plan
- [x] Script parses cleanly (\`[Parser]::ParseFile\`)
- [ ] Dry-run against a staging Immich: lists tags, prompts, deletes on confirm
- [ ] Verify assets still exist after bulk delete (only tag associations are gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)