### PR TITLE
feat(tasks): tag assets by folder structure

### DIFF
--- a/FL.LigaImmich.Tests/FolderTagResolverTests.cs
+++ b/FL.LigaImmich.Tests/FolderTagResolverTests.cs
@@ -1,0 +1,57 @@
+using FL.LigaImmich.Folders;
+
+namespace FL.LigaImmich.Tests;
+
+public class FolderTagResolverTests
+{
+    [Theory]
+    [InlineData(
+        "archiv/Digitalfoto/2019/F-Film-Liga/F_2019-07-20_Sommerfest",
+        "Digitalfoto/2019/F-Film-Liga/F_2019-07-20_Sommerfest")]
+    [InlineData(
+        "/usr/src/app/external/archiv/Digitalfoto/2019/M-Musikverein/M_2019-05-00_Probenwoche",
+        "Digitalfoto/2019/M-Musikverein/M_2019-05-00_Probenwoche")]
+    [InlineData(
+        "Digitalfoto\\2025\\C-Gemischter_Chor\\Auftritt",
+        "Digitalfoto/2025/C-Gemischter_Chor/Auftritt")]
+    [InlineData(
+        "Digitalfoto/2025",
+        "Digitalfoto/2025")]
+    public void TryResolveTag_BuildsTagFromArchiveRoot_OnwardsThroughFolderPath(string path, string expected)
+    {
+        Assert.True(FolderTagResolver.TryResolveTag(path, out var tag));
+        Assert.Equal(expected, tag);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("archiv/Scan-Dia/2019/F-Film-Liga")]
+    [InlineData("some/other/tree/without/the/anchor")]
+    public void TryResolveTag_ReturnsFalse_WhenArchiveRootNotInPath(string path)
+    {
+        Assert.False(FolderTagResolver.TryResolveTag(path, out var tag));
+        Assert.Equal(string.Empty, tag);
+    }
+
+    [Fact]
+    public void TryResolveTag_ReturnsFalse_WhenArchiveRootIsTheLastSegment()
+    {
+        // Nothing to tag below the anchor — the resolver should not emit a bare
+        // "Digitalfoto" tag when no year/club/event folder follows.
+        Assert.False(FolderTagResolver.TryResolveTag("archiv/Digitalfoto", out var tag));
+        Assert.Equal(string.Empty, tag);
+    }
+
+    [Fact]
+    public void TryResolveTag_MatchesArchiveRootCaseInsensitively_AndNormalizesToCanonicalCasing()
+    {
+        Assert.True(FolderTagResolver.TryResolveTag("archiv/digitalfoto/2019/F-Film-Liga/event", out var tag));
+        Assert.Equal("Digitalfoto/2019/F-Film-Liga/event", tag);
+    }
+
+    [Fact]
+    public void ArchiveRoots_IncludesDigitalfoto()
+    {
+        Assert.Contains("Digitalfoto", FolderTagResolver.ArchiveRoots);
+    }
+}

--- a/FL.LigaImmich.Tests/FolderTagResolverTests.cs
+++ b/FL.LigaImmich.Tests/FolderTagResolverTests.cs
@@ -17,6 +17,18 @@ public class FolderTagResolverTests
     [InlineData(
         "Digitalfoto/2025",
         "Digitalfoto/2025")]
+    [InlineData(
+        "archiv/Dia/1975/F-Film-Liga/event",
+        "Dia/1975/F-Film-Liga/event")]
+    [InlineData(
+        "archiv/Negativ/1980/M-Musikverein/Konzert",
+        "Negativ/1980/M-Musikverein/Konzert")]
+    [InlineData(
+        "archiv/Ton/1990/F-Film-Liga/recording",
+        "Ton/1990/F-Film-Liga/recording")]
+    [InlineData(
+        "archiv/Video/2000/N-Narrenzunft/Umzug",
+        "Video/2000/N-Narrenzunft/Umzug")]
     public void TryResolveTag_BuildsTagFromArchiveRoot_OnwardsThroughFolderPath(string path, string expected)
     {
         Assert.True(FolderTagResolver.TryResolveTag(path, out var tag));
@@ -27,6 +39,7 @@ public class FolderTagResolverTests
     [InlineData("")]
     [InlineData("archiv/Scan-Dia/2019/F-Film-Liga")]
     [InlineData("some/other/tree/without/the/anchor")]
+    [InlineData("archiv/Audio/1990/F-Film-Liga/recording")]
     public void TryResolveTag_ReturnsFalse_WhenArchiveRootNotInPath(string path)
     {
         Assert.False(FolderTagResolver.TryResolveTag(path, out var tag));
@@ -50,8 +63,12 @@ public class FolderTagResolverTests
     }
 
     [Fact]
-    public void ArchiveRoots_IncludesDigitalfoto()
+    public void ArchiveRoots_IncludesAllExpectedMediaBranches()
     {
         Assert.Contains("Digitalfoto", FolderTagResolver.ArchiveRoots);
+        Assert.Contains("Dia", FolderTagResolver.ArchiveRoots);
+        Assert.Contains("Negativ", FolderTagResolver.ArchiveRoots);
+        Assert.Contains("Ton", FolderTagResolver.ArchiveRoots);
+        Assert.Contains("Video", FolderTagResolver.ArchiveRoots);
     }
 }

--- a/FL.LigaImmich/EnvironmentVariableConfiguration.cs
+++ b/FL.LigaImmich/EnvironmentVariableConfiguration.cs
@@ -10,6 +10,9 @@ internal static class EnvironmentVariableConfiguration
         ["SCHEDULER_TAG_ASSETS_BY_CLUB_CRON"] = "Scheduler:Tasks:TagAssetsByClub:Cron",
         ["SCHEDULER_TAG_ASSETS_BY_CLUB_ENABLED"] = "Scheduler:Tasks:TagAssetsByClub:Enabled",
         ["SCHEDULER_TAG_ASSETS_BY_CLUB_RUN_ON_STARTUP"] = "Scheduler:Tasks:TagAssetsByClub:RunOnStartup",
+        ["SCHEDULER_TAG_ASSETS_BY_FOLDER_STRUCTURE_CRON"] = "Scheduler:Tasks:TagAssetsByFolderStructure:Cron",
+        ["SCHEDULER_TAG_ASSETS_BY_FOLDER_STRUCTURE_ENABLED"] = "Scheduler:Tasks:TagAssetsByFolderStructure:Enabled",
+        ["SCHEDULER_TAG_ASSETS_BY_FOLDER_STRUCTURE_RUN_ON_STARTUP"] = "Scheduler:Tasks:TagAssetsByFolderStructure:RunOnStartup",
     };
 
     public static IConfigurationBuilder AddLigaImmichEnvironmentVariables(this IConfigurationBuilder builder)

--- a/FL.LigaImmich/Folders/FolderTagResolver.cs
+++ b/FL.LigaImmich/Folders/FolderTagResolver.cs
@@ -11,6 +11,10 @@ internal static class FolderTagResolver
     public static IReadOnlyCollection<string> ArchiveRoots { get; } =
     [
         "Digitalfoto",
+        "Dia",
+        "Negativ",
+        "Ton",
+        "Video",
     ];
 
     // Maps the case-insensitive root key to its canonical (configured) casing

--- a/FL.LigaImmich/Folders/FolderTagResolver.cs
+++ b/FL.LigaImmich/Folders/FolderTagResolver.cs
@@ -1,0 +1,47 @@
+namespace FL.LigaImmich.Folders;
+
+internal static class FolderTagResolver
+{
+    private static readonly char[] Separators = ['/', '\\'];
+
+    // Top-level folders that anchor the tag hierarchy. When one of these
+    // segments appears in an asset's original path, the tag is built from
+    // that segment through the end of the folder path (case-sensitive output,
+    // case-insensitive match to tolerate filesystem casing).
+    public static IReadOnlyCollection<string> ArchiveRoots { get; } =
+    [
+        "Digitalfoto",
+    ];
+
+    // Maps the case-insensitive root key to its canonical (configured) casing
+    // so the emitted tag is stable regardless of how the filesystem spells it.
+    private static readonly Dictionary<string, string> CanonicalRoot =
+        ArchiveRoots.ToDictionary(r => r, r => r, StringComparer.OrdinalIgnoreCase);
+
+    public static bool TryResolveTag(string path, out string tagValue)
+    {
+        if (!string.IsNullOrEmpty(path))
+        {
+            var segments = path.Split(Separators, StringSplitOptions.RemoveEmptyEntries);
+            for (var i = 0; i < segments.Length; i++)
+            {
+                if (!CanonicalRoot.TryGetValue(segments[i], out var canonical))
+                {
+                    continue;
+                }
+
+                if (i == segments.Length - 1)
+                {
+                    break;
+                }
+
+                segments[i] = canonical;
+                tagValue = string.Join('/', segments[i..]);
+                return true;
+            }
+        }
+
+        tagValue = string.Empty;
+        return false;
+    }
+}

--- a/FL.LigaImmich/Program.cs
+++ b/FL.LigaImmich/Program.cs
@@ -15,6 +15,7 @@ builder.Services.AddOptions<SchedulerOptions>()
 builder.Services.AddImmichClient(builder.Configuration);
 
 builder.Services.AddScheduledTask<TagAssetsByClubTask>();
+builder.Services.AddScheduledTask<TagAssetsByFolderStructureTask>();
 
 builder.Services.AddHostedService<CronSchedulerService>();
 

--- a/FL.LigaImmich/Tasks/TagAssetsByFolderStructureTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByFolderStructureTask.cs
@@ -1,0 +1,118 @@
+using FL.LigaImmich.Folders;
+using FL.LigaImmich.ImmichClient;
+using FL.LigaImmich.Scheduling;
+using Microsoft.Extensions.Logging;
+
+namespace FL.LigaImmich.Tasks;
+
+internal sealed class TagAssetsByFolderStructureTask : IScheduledTask
+{
+    private const int BulkTagBatchSize = 500;
+
+    private readonly IImmichClient _immichClient;
+    private readonly ILogger<TagAssetsByFolderStructureTask> _logger;
+
+    public TagAssetsByFolderStructureTask(IImmichClient immichClient, ILogger<TagAssetsByFolderStructureTask> logger)
+    {
+        _immichClient = immichClient;
+        _logger = logger;
+    }
+
+    public string Name => "TagAssetsByFolderStructure";
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var folderPaths = await _immichClient.GetUniqueOriginalPathsAsync(cancellationToken);
+        _logger.LogInformation("Fetched {Count} unique folder paths from Immich.", folderPaths.Count);
+
+        var assetsByTag = new Dictionary<string, HashSet<Guid>>(StringComparer.Ordinal);
+
+        foreach (var folder in folderPaths)
+        {
+            if (!FolderTagResolver.TryResolveTag(folder, out var tagValue))
+            {
+                continue;
+            }
+
+            var assets = await _immichClient.GetAssetsByOriginalPathAsync(folder, cancellationToken);
+            if (assets.Count == 0)
+            {
+                continue;
+            }
+
+            if (!assetsByTag.TryGetValue(tagValue, out var set))
+            {
+                assetsByTag[tagValue] = set = [];
+            }
+
+            foreach (var asset in assets)
+            {
+                if (Guid.TryParse(asset.Id, out var assetId))
+                {
+                    set.Add(assetId);
+                }
+            }
+        }
+
+        if (assetsByTag.Count == 0)
+        {
+            return;
+        }
+
+        var tagIdByValue = await EnsureTagsAsync(assetsByTag.Keys, cancellationToken);
+
+        foreach (var (tagValue, assetIds) in assetsByTag)
+        {
+            if (assetIds.Count == 0)
+            {
+                continue;
+            }
+
+            if (!tagIdByValue.TryGetValue(tagValue, out var tagId))
+            {
+                _logger.LogWarning("Skipping tag {TagValue}: no id resolved after upsert.", tagValue);
+                continue;
+            }
+
+            var tagged = 0;
+            foreach (var batch in assetIds.Chunk(BulkTagBatchSize))
+            {
+                var dto = new TagBulkAssetsDto
+                {
+                    TagIds = { tagId },
+                };
+                foreach (var id in batch)
+                {
+                    dto.AssetIds.Add(id);
+                }
+
+                var response = await _immichClient.BulkTagAssetsAsync(dto, cancellationToken);
+                tagged += response.Count;
+            }
+
+            _logger.LogInformation("Tagged {Tagged}/{Total} assets with {TagValue}.", tagged, assetIds.Count, tagValue);
+        }
+    }
+
+    private async Task<Dictionary<string, Guid>> EnsureTagsAsync(IEnumerable<string> tagValues, CancellationToken cancellationToken)
+    {
+        var upsert = new TagUpsertDto();
+        foreach (var value in tagValues)
+        {
+            upsert.Tags.Add(value);
+        }
+
+        var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
+
+        var byValue = new Dictionary<string, Guid>(StringComparer.Ordinal);
+        foreach (var tag in tags)
+        {
+            if (Guid.TryParse(tag.Id, out var id))
+            {
+                byValue[tag.Value] = id;
+            }
+        }
+
+        return byValue;
+    }
+}

--- a/FL.LigaImmich/appsettings.json
+++ b/FL.LigaImmich/appsettings.json
@@ -11,7 +11,8 @@
   "Scheduler": {
     "TimeZone": "Europe/Berlin",
     "Tasks": {
-      "TagAssetsByClub": { "Cron": "0 15 3 * * *", "Enabled": true }
+      "TagAssetsByClub": { "Cron": "0 15 3 * * *", "Enabled": true },
+      "TagAssetsByFolderStructure": { "Cron": "0 30 3 * * *", "Enabled": true }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ docker run --rm \
 
 The worker exposes a Docker-friendly `SCREAMING_SNAKE_CASE` env var for each setting in [appsettings.json](FL.LigaImmich/appsettings.json). These are mapped to the underlying .NET config keys at startup (see [EnvironmentVariableConfiguration.cs](FL.LigaImmich/EnvironmentVariableConfiguration.cs)):
 
-| Setting                                   | Env var                                | Description                                                          |
-| ----------------------------------------- | -------------------------------------- | -------------------------------------------------------------------- |
-| `Immich:BaseUrl`                          | `IMMICH_BASE_URL`                      | Immich API base URL (e.g. `https://immich.example.com/api`).         |
-| `Immich:ApiKey`                           | `IMMICH_API_KEY`                       | Immich API key.                                                      |
-| `Scheduler:TimeZone`                      | `SCHEDULER_TIMEZONE`                   | IANA time zone used for cron expressions (default: `Europe/Berlin`). |
-| `Scheduler:Tasks:TagAssetsByClub:Cron`    | `SCHEDULER_TAG_ASSETS_BY_CLUB_CRON`    | Cron expression for the club-tag task.                               |
-| `Scheduler:Tasks:TagAssetsByClub:Enabled` | `SCHEDULER_TAG_ASSETS_BY_CLUB_ENABLED` | Enable/disable the club-tag task.                                    |
+| Setting                                              | Env var                                            | Description                                                          |
+| ---------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------- |
+| `Immich:BaseUrl`                                     | `IMMICH_BASE_URL`                                  | Immich API base URL (e.g. `https://immich.example.com/api`).         |
+| `Immich:ApiKey`                                      | `IMMICH_API_KEY`                                   | Immich API key.                                                      |
+| `Scheduler:TimeZone`                                 | `SCHEDULER_TIMEZONE`                               | IANA time zone used for cron expressions (default: `Europe/Berlin`). |
+| `Scheduler:Tasks:TagAssetsByClub:Cron`               | `SCHEDULER_TAG_ASSETS_BY_CLUB_CRON`                | Cron expression for the club-tag task.                               |
+| `Scheduler:Tasks:TagAssetsByClub:Enabled`            | `SCHEDULER_TAG_ASSETS_BY_CLUB_ENABLED`             | Enable/disable the club-tag task.                                    |
+| `Scheduler:Tasks:TagAssetsByFolderStructure:Cron`    | `SCHEDULER_TAG_ASSETS_BY_FOLDER_STRUCTURE_CRON`    | Cron expression for the folder-structure-tag task.                   |
+| `Scheduler:Tasks:TagAssetsByFolderStructure:Enabled` | `SCHEDULER_TAG_ASSETS_BY_FOLDER_STRUCTURE_ENABLED` | Enable/disable the folder-structure-tag task.                        |
 
 ## Regenerating the Immich client
 


### PR DESCRIPTION
## Summary
- Adds a new scheduled task `TagAssetsByFolderStructure` that tags each asset with a nested Immich tag mirroring its archive folder path (anchored at `Digitalfoto`, e.g. `Digitalfoto/2019/F-Film-Liga/F_2019-07-20_Sommerfest`).
- Introduces `FolderTagResolver` which walks a path, finds the archive-root segment (case-insensitive, canonical casing on output), and emits the remainder as a `/`-joined nested tag. Skips paths with no root match or no folder below the root.
- Wires the task into DI, `appsettings.json` (daily at 03:30), and env-var aliases (`SCHEDULER_TAG_ASSETS_BY_FOLDER_STRUCTURE_*`). README updated.

Closes #21

## Test plan
- [x] `dotnet build FL.LigaImmich.slnx` — green, no warnings.
- [x] `dotnet test FL.LigaImmich.slnx` — 26/26 pass, incl. new `FolderTagResolverTests`.
- [x] Smoke run against a real Immich instance to confirm nested tags are created and assets get tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)