### PR TITLE
fix(clubs): rename Vereine parent tag to _Vereine

### DIFF
--- a/FL.LigaImmich.Tests/ClubFolderMapTests.cs
+++ b/FL.LigaImmich.Tests/ClubFolderMapTests.cs
@@ -5,11 +5,11 @@ namespace FL.LigaImmich.Tests;
 public class ClubFolderMapTests
 {
     [Theory]
-    [InlineData("Digitalfoto/2025/M-Musikverein/M_2025-01-11_Konzert/M_2025-01-11_001.JPG", "Vereine/Musikverein")]
-    [InlineData("/Digitalfoto/2024/N-Narrenzunft/Umzug", "Vereine/Narrenzunft")]
-    [InlineData("Digitalfoto\\2025\\C-Gemischter_Chor\\Auftritt", "Vereine/Gemischter Chor")]
-    [InlineData("Digitalfoto/2025/P-Personen_und_Begebenheiten/event", "Vereine/Personen und Begebenheiten")]
-    [InlineData("Digitalfoto/2025/T-TSV", "Vereine/TSV")]
+    [InlineData("Digitalfoto/2025/M-Musikverein/M_2025-01-11_Konzert/M_2025-01-11_001.JPG", "_Vereine/Musikverein")]
+    [InlineData("/Digitalfoto/2024/N-Narrenzunft/Umzug", "_Vereine/Narrenzunft")]
+    [InlineData("Digitalfoto\\2025\\C-Gemischter_Chor\\Auftritt", "_Vereine/Gemischter Chor")]
+    [InlineData("Digitalfoto/2025/P-Personen_und_Begebenheiten/event", "_Vereine/Personen und Begebenheiten")]
+    [InlineData("Digitalfoto/2025/T-TSV", "_Vereine/TSV")]
     public void TryResolveTag_ReturnsNestedTagValue_ForKnownClubFolder(string path, string expected)
     {
         Assert.True(ClubFolderMap.TryResolveTag(path, out var tag));
@@ -30,7 +30,7 @@ public class ClubFolderMapTests
     public void TryResolveTag_IsCaseInsensitive_OnFolderToken()
     {
         Assert.True(ClubFolderMap.TryResolveTag("Digitalfoto/2025/m-musikverein/img.jpg", out var tag));
-        Assert.Equal("Vereine/Musikverein", tag);
+        Assert.Equal("_Vereine/Musikverein", tag);
     }
 
     [Fact]
@@ -46,6 +46,6 @@ public class ClubFolderMapTests
     public void TagValues_AreAllNestedUnderVereineParent()
     {
         Assert.Equal(ClubFolderMap.LeafTagNames.Count, ClubFolderMap.TagValues.Count);
-        Assert.All(ClubFolderMap.TagValues, value => Assert.StartsWith("Vereine/", value));
+        Assert.All(ClubFolderMap.TagValues, value => Assert.StartsWith("_Vereine/", value));
     }
 }

--- a/FL.LigaImmich/Clubs/ClubFolderMap.cs
+++ b/FL.LigaImmich/Clubs/ClubFolderMap.cs
@@ -2,7 +2,7 @@ namespace FL.LigaImmich.Clubs;
 
 internal static class ClubFolderMap
 {
-    public const string ParentTag = "Vereine";
+    public const string ParentTag = "_Vereine";
 
     // Source of truth: https://github.com/filmliga66/archivstruktur/blob/main/reference/clubs.json
     private static readonly Dictionary<string, string> FolderToLeafTag = new(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary
- Renames the `Vereine` parent tag to `_Vereine` in `ClubFolderMap.ParentTag`
- Updates all tests to expect the new `_Vereine/` prefix

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)