### PR TITLE
fix(tasks): skip assets that already have the target tag

### DIFF
--- a/FL.LigaImmich/Tasks/TagAssetsByClubTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByClubTask.cs
@@ -51,7 +51,8 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
 
             foreach (var asset in assets)
             {
-                if (Guid.TryParse(asset.Id, out var assetId))
+                if (Guid.TryParse(asset.Id, out var assetId)
+                    && !asset.Tags.Any(t => string.Equals(t.Value, tagValue, StringComparison.Ordinal)))
                 {
                     set.Add(assetId);
                 }

--- a/FL.LigaImmich/Tasks/TagAssetsByFolderStructureTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByFolderStructureTask.cs
@@ -47,7 +47,8 @@ internal sealed class TagAssetsByFolderStructureTask : IScheduledTask
 
             foreach (var asset in assets)
             {
-                if (Guid.TryParse(asset.Id, out var assetId))
+                if (Guid.TryParse(asset.Id, out var assetId)
+                    && !asset.Tags.Any(t => string.Equals(t.Value, tagValue, StringComparison.Ordinal)))
                 {
                     set.Add(assetId);
                 }


### PR DESCRIPTION
## Summary
- In both `TagAssetsByClubTask` and `TagAssetsByFolderStructureTask`, assets that already carry the resolved tag value are now filtered out before being added to the bulk-tag batch
- Uses the `Tags` collection already present on `AssetResponseDto` — no extra API calls needed
- Subsequent runs become no-ops for already-tagged assets

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)