### PR TITLE
Ordnerstruktur-Tags unter Parent-Tag

### DIFF
--- a/FL.LigaImmich.Tests/FolderTagResolverTests.cs
+++ b/FL.LigaImmich.Tests/FolderTagResolverTests.cs
@@ -7,28 +7,28 @@ public class FolderTagResolverTests
     [Theory]
     [InlineData(
         "archiv/Digitalfoto/2019/F-Film-Liga/F_2019-07-20_Sommerfest",
-        "Digitalfoto/2019/F-Film-Liga/F_2019-07-20_Sommerfest")]
+        "Ordnerstruktur/Digitalfoto/2019/F-Film-Liga/F_2019-07-20_Sommerfest")]
     [InlineData(
         "/usr/src/app/external/archiv/Digitalfoto/2019/M-Musikverein/M_2019-05-00_Probenwoche",
-        "Digitalfoto/2019/M-Musikverein/M_2019-05-00_Probenwoche")]
+        "Ordnerstruktur/Digitalfoto/2019/M-Musikverein/M_2019-05-00_Probenwoche")]
     [InlineData(
         "Digitalfoto\\2025\\C-Gemischter_Chor\\Auftritt",
-        "Digitalfoto/2025/C-Gemischter_Chor/Auftritt")]
+        "Ordnerstruktur/Digitalfoto/2025/C-Gemischter_Chor/Auftritt")]
     [InlineData(
         "Digitalfoto/2025",
-        "Digitalfoto/2025")]
+        "Ordnerstruktur/Digitalfoto/2025")]
     [InlineData(
         "archiv/Dia/1975/F-Film-Liga/event",
-        "Dia/1975/F-Film-Liga/event")]
+        "Ordnerstruktur/Dia/1975/F-Film-Liga/event")]
     [InlineData(
         "archiv/Negativ/1980/M-Musikverein/Konzert",
-        "Negativ/1980/M-Musikverein/Konzert")]
+        "Ordnerstruktur/Negativ/1980/M-Musikverein/Konzert")]
     [InlineData(
         "archiv/Ton/1990/F-Film-Liga/recording",
-        "Ton/1990/F-Film-Liga/recording")]
+        "Ordnerstruktur/Ton/1990/F-Film-Liga/recording")]
     [InlineData(
         "archiv/Video/2000/N-Narrenzunft/Umzug",
-        "Video/2000/N-Narrenzunft/Umzug")]
+        "Ordnerstruktur/Video/2000/N-Narrenzunft/Umzug")]
     public void TryResolveTag_BuildsTagFromArchiveRoot_OnwardsThroughFolderPath(string path, string expected)
     {
         Assert.True(FolderTagResolver.TryResolveTag(path, out var tag));
@@ -59,7 +59,7 @@ public class FolderTagResolverTests
     public void TryResolveTag_MatchesArchiveRootCaseInsensitively_AndNormalizesToCanonicalCasing()
     {
         Assert.True(FolderTagResolver.TryResolveTag("archiv/digitalfoto/2019/F-Film-Liga/event", out var tag));
-        Assert.Equal("Digitalfoto/2019/F-Film-Liga/event", tag);
+        Assert.Equal("Ordnerstruktur/Digitalfoto/2019/F-Film-Liga/event", tag);
     }
 
     [Fact]
@@ -70,5 +70,12 @@ public class FolderTagResolverTests
         Assert.Contains("Negativ", FolderTagResolver.ArchiveRoots);
         Assert.Contains("Ton", FolderTagResolver.ArchiveRoots);
         Assert.Contains("Video", FolderTagResolver.ArchiveRoots);
+    }
+
+    [Fact]
+    public void TagValues_AreAllNestedUnderOrdnerstrukturParent()
+    {
+        Assert.Equal(FolderTagResolver.ArchiveRoots.Count, FolderTagResolver.TagValues.Count);
+        Assert.All(FolderTagResolver.TagValues, value => Assert.StartsWith("Ordnerstruktur/", value));
     }
 }

--- a/FL.LigaImmich/Folders/FolderTagResolver.cs
+++ b/FL.LigaImmich/Folders/FolderTagResolver.cs
@@ -2,6 +2,8 @@ namespace FL.LigaImmich.Folders;
 
 internal static class FolderTagResolver
 {
+    public const string ParentTag = "Ordnerstruktur";
+
     private static readonly char[] Separators = ['/', '\\'];
 
     // Top-level folders that anchor the tag hierarchy. When one of these
@@ -22,6 +24,9 @@ internal static class FolderTagResolver
     private static readonly Dictionary<string, string> CanonicalRoot =
         ArchiveRoots.ToDictionary(r => r, r => r, StringComparer.OrdinalIgnoreCase);
 
+    public static IReadOnlyCollection<string> TagValues { get; } =
+        ArchiveRoots.Select(ToTagValue).ToArray();
+
     public static bool TryResolveTag(string path, out string tagValue)
     {
         if (!string.IsNullOrEmpty(path))
@@ -40,7 +45,7 @@ internal static class FolderTagResolver
                 }
 
                 segments[i] = canonical;
-                tagValue = string.Join('/', segments[i..]);
+                tagValue = ToTagValue(string.Join('/', segments[i..]));
                 return true;
             }
         }
@@ -48,4 +53,6 @@ internal static class FolderTagResolver
         tagValue = string.Empty;
         return false;
     }
+
+    public static string ToTagValue(string value) => $"{ParentTag}/{value}";
 }

--- a/FL.LigaImmich/Tasks/TagAssetsByClubTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByClubTask.cs
@@ -52,7 +52,7 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
             foreach (var asset in assets)
             {
                 if (Guid.TryParse(asset.Id, out var assetId)
-                    && !asset.Tags.Any(t => string.Equals(t.Value, tagValue, StringComparison.Ordinal)))
+                    && !(asset.Tags?.Any(t => string.Equals(t.Value, tagValue, StringComparison.Ordinal)) ?? false))
                 {
                     set.Add(assetId);
                 }

--- a/FL.LigaImmich/Tasks/TagAssetsByFolderStructureTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByFolderStructureTask.cs
@@ -48,7 +48,7 @@ internal sealed class TagAssetsByFolderStructureTask : IScheduledTask
             foreach (var asset in assets)
             {
                 if (Guid.TryParse(asset.Id, out var assetId)
-                    && !asset.Tags.Any(t => string.Equals(t.Value, tagValue, StringComparison.Ordinal)))
+                    && !(asset.Tags?.Any(t => string.Equals(t.Value, tagValue, StringComparison.Ordinal)) ?? false))
                 {
                     set.Add(assetId);
                 }

--- a/FL.LigaImmich/Tasks/TagAssetsByYearTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByYearTask.cs
@@ -48,7 +48,7 @@ internal sealed class TagAssetsByYearTask : IScheduledTask
             foreach (var asset in assets)
             {
                 if (Guid.TryParse(asset.Id, out var assetId)
-                    && !asset.Tags.Any(t => string.Equals(t.Value, tagValue, StringComparison.Ordinal)))
+                    && !(asset.Tags?.Any(t => string.Equals(t.Value, tagValue, StringComparison.Ordinal)) ?? false))
                 {
                     set.Add(assetId);
                 }

--- a/FL.LigaImmich/appsettings.json
+++ b/FL.LigaImmich/appsettings.json
@@ -12,7 +12,8 @@
     "TimeZone": "Europe/Berlin",
     "Tasks": {
       "TagAssetsByClub": { "Cron": "0 15 3 * * *", "Enabled": true },
-      "TagAssetsByFolderStructure": { "Cron": "0 30 3 * * *", "Enabled": true }
+      "TagAssetsByFolderStructure": { "Cron": "0 30 3 * * *", "Enabled": true },
+      "TagAssetsByYear": { "Cron": "0 45 3 * * *", "Enabled": true }
     }
   }
 }


### PR DESCRIPTION
## Summary\n- implement issue #31\n- nest all folder-structure tags under parent tag Ordnerstruktur\n- update tests for resolver output and parent-tag invariants\n\n## Validation\n- dotnet build FL.LigaImmich.slnx\n- dotnet test FL.LigaImmich.Tests/FL.LigaImmich.Tests.csproj\n\nCloses #31