### PR TITLE
fix: chunk tag upserts to prevent timeout in startup tasks

### DIFF
--- a/FL.LigaImmich/Tasks/TagAssetsByClubTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByClubTask.cs
@@ -8,6 +8,7 @@ namespace FL.LigaImmich.Tasks;
 internal sealed class TagAssetsByClubTask : IScheduledTask
 {
     private const int BulkTagBatchSize = 500;
+    private const int UpsertTagBatchSize = 100;
 
     private readonly IImmichClient _immichClient;
     private readonly ILogger<TagAssetsByClubTask> _logger;
@@ -94,20 +95,26 @@ internal sealed class TagAssetsByClubTask : IScheduledTask
 
     private async Task<Dictionary<string, Guid>> EnsureClubTagsAsync(CancellationToken cancellationToken)
     {
-        var upsert = new TagUpsertDto();
-        foreach (var value in ClubFolderMap.TagValues)
-        {
-            upsert.Tags.Add(value);
-        }
-
-        var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
-
         var byValue = new Dictionary<string, Guid>(StringComparer.Ordinal);
-        foreach (var tag in tags)
+        foreach (var batch in ClubFolderMap.TagValues
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .Chunk(UpsertTagBatchSize))
         {
-            if (Guid.TryParse(tag.Id, out var id))
+            var upsert = new TagUpsertDto();
+            foreach (var value in batch)
             {
-                byValue[tag.Value] = id;
+                upsert.Tags.Add(value);
+            }
+
+            var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
+
+            foreach (var tag in tags)
+            {
+                if (Guid.TryParse(tag.Id, out var id))
+                {
+                    byValue[tag.Value] = id;
+                }
             }
         }
 

--- a/FL.LigaImmich/Tasks/TagAssetsByEventTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByEventTask.cs
@@ -8,6 +8,7 @@ namespace FL.LigaImmich.Tasks;
 internal sealed class TagAssetsByEventTask : IScheduledTask
 {
     private const int BulkTagBatchSize = 500;
+    private const int UpsertTagBatchSize = 100;
 
     private readonly IImmichClient _immichClient;
     private readonly ILogger<TagAssetsByEventTask> _logger;
@@ -97,20 +98,26 @@ internal sealed class TagAssetsByEventTask : IScheduledTask
 
     private async Task<Dictionary<string, Guid>> EnsureTagsAsync(IEnumerable<string> tagValues, CancellationToken cancellationToken)
     {
-        var upsert = new TagUpsertDto();
-        foreach (var value in tagValues)
-        {
-            upsert.Tags.Add(value);
-        }
-
-        var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
-
         var byValue = new Dictionary<string, Guid>(StringComparer.Ordinal);
-        foreach (var tag in tags)
+        foreach (var batch in tagValues
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .Chunk(UpsertTagBatchSize))
         {
-            if (Guid.TryParse(tag.Id, out var id))
+            var upsert = new TagUpsertDto();
+            foreach (var value in batch)
             {
-                byValue[tag.Value] = id;
+                upsert.Tags.Add(value);
+            }
+
+            var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
+
+            foreach (var tag in tags)
+            {
+                if (Guid.TryParse(tag.Id, out var id))
+                {
+                    byValue[tag.Value] = id;
+                }
             }
         }
 

--- a/FL.LigaImmich/Tasks/TagAssetsByFolderStructureTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByFolderStructureTask.cs
@@ -8,6 +8,7 @@ namespace FL.LigaImmich.Tasks;
 internal sealed class TagAssetsByFolderStructureTask : IScheduledTask
 {
     private const int BulkTagBatchSize = 500;
+    private const int UpsertTagBatchSize = 100;
 
     private readonly IImmichClient _immichClient;
     private readonly ILogger<TagAssetsByFolderStructureTask> _logger;
@@ -97,20 +98,26 @@ internal sealed class TagAssetsByFolderStructureTask : IScheduledTask
 
     private async Task<Dictionary<string, Guid>> EnsureTagsAsync(IEnumerable<string> tagValues, CancellationToken cancellationToken)
     {
-        var upsert = new TagUpsertDto();
-        foreach (var value in tagValues)
-        {
-            upsert.Tags.Add(value);
-        }
-
-        var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
-
         var byValue = new Dictionary<string, Guid>(StringComparer.Ordinal);
-        foreach (var tag in tags)
+        foreach (var batch in tagValues
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .Chunk(UpsertTagBatchSize))
         {
-            if (Guid.TryParse(tag.Id, out var id))
+            var upsert = new TagUpsertDto();
+            foreach (var value in batch)
             {
-                byValue[tag.Value] = id;
+                upsert.Tags.Add(value);
+            }
+
+            var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
+
+            foreach (var tag in tags)
+            {
+                if (Guid.TryParse(tag.Id, out var id))
+                {
+                    byValue[tag.Value] = id;
+                }
             }
         }
 

--- a/FL.LigaImmich/Tasks/TagAssetsByYearTask.cs
+++ b/FL.LigaImmich/Tasks/TagAssetsByYearTask.cs
@@ -8,6 +8,7 @@ namespace FL.LigaImmich.Tasks;
 internal sealed class TagAssetsByYearTask : IScheduledTask
 {
     private const int BulkTagBatchSize = 500;
+    private const int UpsertTagBatchSize = 100;
 
     private readonly IImmichClient _immichClient;
     private readonly ILogger<TagAssetsByYearTask> _logger;
@@ -97,20 +98,26 @@ internal sealed class TagAssetsByYearTask : IScheduledTask
 
     private async Task<Dictionary<string, Guid>> EnsureTagsAsync(IEnumerable<string> tagValues, CancellationToken cancellationToken)
     {
-        var upsert = new TagUpsertDto();
-        foreach (var value in tagValues)
-        {
-            upsert.Tags.Add(value);
-        }
-
-        var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
-
         var byValue = new Dictionary<string, Guid>(StringComparer.Ordinal);
-        foreach (var tag in tags)
+        foreach (var batch in tagValues
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .Chunk(UpsertTagBatchSize))
         {
-            if (Guid.TryParse(tag.Id, out var id))
+            var upsert = new TagUpsertDto();
+            foreach (var value in batch)
             {
-                byValue[tag.Value] = id;
+                upsert.Tags.Add(value);
+            }
+
+            var tags = await _immichClient.UpsertTagsAsync(upsert, cancellationToken);
+
+            foreach (var tag in tags)
+            {
+                if (Guid.TryParse(tag.Id, out var id))
+                {
+                    byValue[tag.Value] = id;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- split tag upsert requests into smaller batches in all tagging tasks
- avoid sending very large TagUpsertDto payloads that can exceed the default 30s HTTP resilience timeout
- keep tag-id resolution behavior unchanged while reducing timeout risk

## Validation
- dotnet build succeeded
- tests passed (55/55)

## Related
- fixes #39